### PR TITLE
Updates Ci Configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-rn:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
 
@@ -31,16 +31,74 @@ jobs:
   test-ios:
     needs: test-rn
     runs-on: macos-13
+    defaults:
+      run:
+        working-directory: example
 
     steps:
-      - name: No-op
-        run: echo "Skipping iOS tests. Job completed successfully."
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.2'
 
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_JS_VERSION }}
+
+      - name: Install NPM dependencies
+        run: npm install
+
+      - name: Install pods
+        run: cd ios && pod install
+
+      - name: Run tests
+        run: cd ios && xcodebuild -workspace example.xcworkspace -scheme "example" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test
 
   test-android:
     needs: test-rn
-    runs-on: macos-13
+    runs-on: macOS-13
+    env:
+      GRADLE_VERSION: 7.6
 
     steps:
-      - name: No-op
-        run: echo "Skipping Android tests. Job completed successfully."
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_JS_VERSION }}
+
+      - name: Java 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+
+      - name: Install Dependencies npm
+        working-directory: ./example
+        run: npm install
+
+      - name: Cache Gradle
+        id: cache-gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./example/android/ci-cache/gradle
+            ./example/android/gradle/wrapper/gradle-wrapper.jar
+            ./example/android/gradlew
+          key: ${{ runner.os }}-cache-gradle-${{ env.GRADLE_VERSION }}
+
+      - name: Setup Gradle
+        if: steps.cache-gradle.outputs.cache-hit != 'true'
+        working-directory: ./example/android
+        run: ../../scripts/setup_gradle.sh ${{ env.GRADLE_VERSION }}
+
+      - name: Android tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          working-directory: ./example/android
+          api-level: 29
+          script: gradle wrapper; ./gradlew :react-native-usercentrics:connectedAndroidTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test-rn:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v1
 
@@ -31,74 +31,16 @@ jobs:
   test-ios:
     needs: test-rn
     runs-on: macos-13
-    defaults:
-      run:
-        working-directory: example
 
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '14.2'
+      - name: No-op
+        run: echo "Skipping iOS tests. Job completed successfully."
 
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_JS_VERSION }}
-
-      - name: Install NPM dependencies
-        run: npm install
-
-      - name: Install pods
-        run: cd ios && pod install
-
-      - name: Run tests
-        run: cd ios && xcodebuild -workspace example.xcworkspace -scheme "example" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test
 
   test-android:
     needs: test-rn
-    runs-on: macOS-13
-    env:
-      GRADLE_VERSION: 7.6
+    runs-on: macos-13
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_JS_VERSION }}
-
-      - name: Java 17
-        uses: actions/setup-java@v1
-        with:
-          java-version: 17
-
-      - name: Install Dependencies npm
-        working-directory: ./example
-        run: npm install
-
-      - name: Cache Gradle
-        id: cache-gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ./example/android/ci-cache/gradle
-            ./example/android/gradle/wrapper/gradle-wrapper.jar
-            ./example/android/gradlew
-          key: ${{ runner.os }}-cache-gradle-${{ env.GRADLE_VERSION }}
-
-      - name: Setup Gradle
-        if: steps.cache-gradle.outputs.cache-hit != 'true'
-        working-directory: ./example/android
-        run: ../../scripts/setup_gradle.sh ${{ env.GRADLE_VERSION }}
-
-      - name: Android tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          working-directory: ./example/android
-          api-level: 29
-          script: gradle wrapper; ./gradlew :react-native-usercentrics:connectedAndroidTest
+      - name: No-op
+        run: echo "Skipping Android tests. Job completed successfully."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_JS_VERSION }}
 
-      - name: Java 11
+      - name: Java 17
         uses: actions/setup-java@v1
         with:
-          java-version: "11"
+          java-version: 17
 
       - name: Install Dependencies npm
         working-directory: ./example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,49 @@ jobs:
       - name: Assert that every file that should be public has been exported
         run: ./scripts/assert_export.sh
 
+  #test-ios:
+    #needs: test-rn
+    #runs-on: macos-13
+    #defaults:
+      #run:
+        #working-directory: example
+
+    #steps:
+      #- uses: maxim-lobanov/setup-xcode@v1
+        #with:
+          #xcode-version: '14.2'
+
+      #- name: Checkout
+        #uses: actions/checkout@v2
+
+      #- name: Setup Node
+        #uses: actions/setup-node@v2
+        #with:
+          #node-version: ${{ env.NODE_JS_VERSION }}
+
+      #- name: Install NPM dependencies
+        #run: npm install
+
+      #- name: Install pods
+        #run: cd ios && pod install
+
+      #- name: Run tests
+        #run: cd ios && xcodebuild -workspace example.xcworkspace -scheme "example" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test
+
   test-ios:
     needs: test-rn
-    runs-on: macos-13
-    defaults:
-      run:
-        working-directory: example
+    runs-on: macOS-13
+    steps:
+      - name: No-op
+        run: echo "Skipping iOS tests. Job completed successfully."
+
+  test-android:
+    needs: test-rn
+    runs-on: macOS-13
+    env:
+      GRADLE_VERSION: 7.6
 
     steps:
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '14.2'
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -48,64 +79,33 @@ jobs:
         with:
           node-version: ${{ env.NODE_JS_VERSION }}
 
-      - name: Install NPM dependencies
+      - name: Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Install Dependencies npm
+        working-directory: ./example
         run: npm install
 
-      - name: Install pods
-        run: cd ios && pod install
+      - name: Cache Gradle
+        id: cache-gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./example/android/ci-cache/gradle
+            ./example/android/gradle/wrapper/gradle-wrapper.jar
+            ./example/android/gradlew
+          key: ${{ runner.os }}-cache-gradle-${{ env.GRADLE_VERSION }}
 
-      - name: Run tests
-        run: cd ios && xcodebuild -workspace example.xcworkspace -scheme "example" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test
+      - name: Setup Gradle
+        if: steps.cache-gradle.outputs.cache-hit != 'true'
+        working-directory: ./example/android
+        run: ../../scripts/setup_gradle.sh ${{ env.GRADLE_VERSION }}
 
-  test-android:
-    needs: test-rn
-    runs-on: macOS-13
-    steps:
-      - name: No-op
-        run: echo "Skipping Android tests. Job completed successfully."
-
-#  test-android:
-#    needs: test-rn
-#    runs-on: macOS-13
-#    env:
-#      GRADLE_VERSION: 7.6
-#
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v2
-#
-#      - name: Setup Node
-#        uses: actions/setup-node@v2
-#        with:
-#          node-version: ${{ env.NODE_JS_VERSION }}
-#
-#      - name: Java 11
-#        uses: actions/setup-java@v1
-#        with:
-#          java-version: 11
-#
-#      - name: Install Dependencies npm
-#        working-directory: ./example
-#        run: npm install
-#
-#      - name: Cache Gradle
-#        id: cache-gradle
-#        uses: actions/cache@v2
-#        with:
-#          path: |
-#            ./example/android/ci-cache/gradle
-#            ./example/android/gradle/wrapper/gradle-wrapper.jar
-#            ./example/android/gradlew
-#          key: ${{ runner.os }}-cache-gradle-${{ env.GRADLE_VERSION }}
-#
-#      - name: Setup Gradle
-#        if: steps.cache-gradle.outputs.cache-hit != 'true'
-#        working-directory: ./example/android
-#        run: ../../scripts/setup_gradle.sh ${{ env.GRADLE_VERSION }}
-#
-#      - name: Android tests
-#        uses: reactivecircus/android-emulator-runner@v2
-#        with:
-#          working-directory: ./example/android
-#          api-level: 29
-#          script: gradle wrapper; ./gradlew :react-native-usercentrics:connectedAndroidTest
+      - name: Android tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          working-directory: ./example/android
+          api-level: 29
+          script: gradle wrapper; ./gradlew :react-native-usercentrics:connectedAndroidTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,51 +11,10 @@ on:
 
 jobs:
   test-rn:
-    runs-on: ubuntu-latest
-
+    runs-on: macOS-13
     steps:
-      - uses: actions/checkout@v1
-
-      - name: Use Node.js "$NODE_JS_VERSION"
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ env.NODE_JS_VERSION }}
-
-      - name: Run RN Tests
-        run: |
-          npm ci
-          npm test
-      - name: Assert that every file that should be public has been exported
-        run: ./scripts/assert_export.sh
-
-  #test-ios:
-    #needs: test-rn
-    #runs-on: macos-13
-    #defaults:
-      #run:
-        #working-directory: example
-
-    #steps:
-      #- uses: maxim-lobanov/setup-xcode@v1
-        #with:
-          #xcode-version: '14.2'
-
-      #- name: Checkout
-        #uses: actions/checkout@v2
-
-      #- name: Setup Node
-        #uses: actions/setup-node@v2
-        #with:
-          #node-version: ${{ env.NODE_JS_VERSION }}
-
-      #- name: Install NPM dependencies
-        #run: npm install
-
-      #- name: Install pods
-        #run: cd ios && pod install
-
-      #- name: Run tests
-        #run: cd ios && xcodebuild -workspace example.xcworkspace -scheme "example" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test
+      - name: No-op
+        run: echo "Skipping RN tests. Job completed successfully."
 
   test-ios:
     needs: test-rn
@@ -72,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v2
@@ -82,7 +41,7 @@ jobs:
       - name: Java 11
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: "11"
 
       - name: Install Dependencies npm
         working-directory: ./example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,51 @@ on:
 
 jobs:
   test-rn:
-    runs-on: macOS-13
+    runs-on: ubuntu-latest
     steps:
-      - name: No-op
-        run: echo "Skipping RN tests. Job completed successfully."
+      - uses: actions/checkout@v1
+
+      - name: Use Node.js "$NODE_JS_VERSION"
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_JS_VERSION }}
+
+      - name: Run RN Tests
+        run: |
+          npm ci
+          npm test
+
+      - name: Assert that every file that should be public has been exported
+        run: ./scripts/assert_export.sh
 
   test-ios:
     needs: test-rn
-    runs-on: macOS-13
+    runs-on: macos-13
+    defaults:
+      run:
+        working-directory: example
+
     steps:
-      - name: No-op
-        run: echo "Skipping iOS tests. Job completed successfully."
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '14.2'
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_JS_VERSION }}
+
+      - name: Install NPM dependencies
+        run: npm install
+
+      - name: Install pods
+        run: cd ios && pod install
+
+      - name: Run tests
+        run: cd ios && xcodebuild -workspace example.xcworkspace -scheme "example" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' test
 
   test-android:
     needs: test-rn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache Gradle
         id: cache-gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ./example/android/ci-cache/gradle


### PR DESCRIPTION
Cache v4 updates: https://github.com/actions/cache

In 2025, ubuntu-latest will become 24.04 version -> https://github.com/actions/runner-images/issues/10636

In order to validate that everything would still work, I manually changed from ubuntu-latest to ubuntu-24.04 and verified that ci steps would still run successfully. After that, reverted to ubuntu-latest again and only updated the actions/cache to the most recent.

<img width="1338" alt="Screenshot 2024-12-16 at 16 12 48" src="https://github.com/user-attachments/assets/e14136e9-d84c-407c-9fb0-c2cd16f1cd44" />

