### PR TITLE
fix: add null safety check for ReadableMap in UserDecisionExtensions

### DIFF
--- a/android/src/main/java/com/usercentrics/reactnativeusercentrics/extensions/BannerSettingsExtensions.kt
+++ b/android/src/main/java/com/usercentrics/reactnativeusercentrics/extensions/BannerSettingsExtensions.kt
@@ -110,9 +110,9 @@ internal fun ReadableMap.buttonLayoutFromMap(context: Context): ButtonLayout? {
             val listRow = mutableListOf<ButtonSettings>()
             val row = buttonsArray.getArray(rowIndex)
 
-            for (rowElement in 0 until row.size()) {
-                val element = row.getMap(rowElement)
-                listRow.add(element.buttonSettingsFromMap(context))
+            for (rowElement in 0 until (row?.size() ?: 0)) {
+                val element = row?.getMap(rowElement)
+                element?.let { listRow.add(it.buttonSettingsFromMap(context)) }
             }
             buttonsList.add(listRow)
         }

--- a/android/src/main/java/com/usercentrics/reactnativeusercentrics/extensions/UserDecisionExtensions.kt
+++ b/android/src/main/java/com/usercentrics/reactnativeusercentrics/extensions/UserDecisionExtensions.kt
@@ -12,7 +12,7 @@ import com.usercentrics.sdk.services.tcf.interfaces.TCFUserDecisions
 internal fun ReadableArray.deserializeUserDecision(): List<UserDecision> {
     val decisionList = mutableListOf<UserDecision>()
     for (i in 0 until size()) {
-        val map = getMap(i)
+        val map = getMap(i) ?: continue
         decisionList.add(
             UserDecision(
                 map.getString("serviceId")!!,
@@ -27,7 +27,8 @@ internal fun ReadableMap.deserializeTCFUserDecisions(): TCFUserDecisions {
     val purposes = getArray("purposes")?.let {
         val list = mutableListOf<TCFUserDecisionOnPurpose>()
         for (i in 0 until it.size()) {
-            list.add(it.getMap(i).deserializeTCFUserDecisionOnPurpose())
+            val map = it.getMap(i) ?: continue
+            list.add(map.deserializeTCFUserDecisionOnPurpose())
         }
         list
     }
@@ -35,7 +36,8 @@ internal fun ReadableMap.deserializeTCFUserDecisions(): TCFUserDecisions {
     val specialFeature = getArray("specialFeatures")?.let {
         val list = mutableListOf<TCFUserDecisionOnSpecialFeature>()
         for (i in 0 until it.size()) {
-            list.add(it.getMap(i).deserializeTCFUserDecisionOnSpecialFeature())
+            val map = it.getMap(i) ?: continue
+            list.add(map.deserializeTCFUserDecisionOnSpecialFeature())
         }
         list
     }
@@ -43,7 +45,8 @@ internal fun ReadableMap.deserializeTCFUserDecisions(): TCFUserDecisions {
     val vendors = getArray("vendors")?.let {
         val list = mutableListOf<TCFUserDecisionOnVendor>()
         for (i in 0 until it.size()) {
-            list.add(it.getMap(i).deserializeTCFUserDecisionOnVendor())
+            val map = it.getMap(i) ?: continue
+            list.add(map.deserializeTCFUserDecisionOnVendor())
         }
         list
     }
@@ -51,7 +54,8 @@ internal fun ReadableMap.deserializeTCFUserDecisions(): TCFUserDecisions {
     val adTechProviderDecisions = getArray("adTechProviders")?.let {
         val list = mutableListOf<AdTechProviderDecision>()
         for (i in 0 until it.size()) {
-            list.add(it.getMap(i).deserializeAdTechProviderDecision())
+            val map = it.getMap(i) ?: continue
+            list.add(map.deserializeAdTechProviderDecision())
         }
         list
     }


### PR DESCRIPTION
# Fix nullable ReadableMap handling in UserDecisionExtensions

## Problem
The current implementation doesn't properly handle nullable `ReadableMap` objects returned by `getMap()`, causing Kotlin compilation errors.

## Solution
Added proper null handling in `UserDecisionExtension.kt` and `BannerSettingsExtension.kt`.