### PR TITLE
Fix Android New Arch Issue

### DIFF
--- a/android/src/main/java/com/usercentrics/reactnative/RNUsercentricsModule.kt
+++ b/android/src/main/java/com/usercentrics/reactnative/RNUsercentricsModule.kt
@@ -95,8 +95,8 @@ internal class RNUsercentricsModule(
     }
 
     @ReactMethod
-    override fun setCMPId(id: Int) {
-        usercentricsProxy.instance.setCMPId(id)
+    override fun setCMPId(id: Double) {
+        usercentricsProxy.instance.setCMPId(id.toInt())
     }
 
     @ReactMethod
@@ -131,37 +131,37 @@ internal class RNUsercentricsModule(
     }
 
     @ReactMethod
-    override fun acceptAllForTCF(fromLayer: Int, consentType: Int, promise: Promise) {
+    override fun acceptAllForTCF(fromLayer: Double, consentType: Double, promise: Promise) {
         promise.resolve(
             usercentricsProxy.instance.acceptAllForTCF(
-                TCFDecisionUILayer.values()[fromLayer], UsercentricsConsentType.values()[consentType]
+                TCFDecisionUILayer.values()[fromLayer.toInt()], UsercentricsConsentType.values()[consentType.toInt()]
             ).toWritableArray()
         )
     }
 
     @ReactMethod
-    override fun acceptAll(consentType: Int, promise: Promise) {
+    override fun acceptAll(consentType: Double, promise: Promise) {
         promise.resolve(
             usercentricsProxy.instance.acceptAll(
-                UsercentricsConsentType.values()[consentType]
+                UsercentricsConsentType.values()[consentType.toInt()]
             ).toWritableArray()
         )
     }
 
     @ReactMethod
-    override fun denyAllForTCF(fromLayer: Int, consentType: Int, unsavedPurposeLIDecisions: ReadableArray, promise: Promise) {
+    override fun denyAllForTCF(fromLayer: Double, consentType: Double, unsavedPurposeLIDecisions: ReadableArray, promise: Promise) {
         promise.resolve(
             usercentricsProxy.instance.denyAllForTCF(
-                TCFDecisionUILayer.values()[fromLayer], UsercentricsConsentType.values()[consentType], unsavedPurposeLIDecisions.deserializePurposeLIDecisionsMap()
+                TCFDecisionUILayer.values()[fromLayer.toInt()], UsercentricsConsentType.values()[consentType.toInt()], unsavedPurposeLIDecisions.deserializePurposeLIDecisionsMap()
             ).toWritableArray()
         )
     }
 
     @ReactMethod
-    override fun denyAll(consentType: Int, promise: Promise) {
+    override fun denyAll(consentType: Double, promise: Promise) {
         promise.resolve(
             usercentricsProxy.instance.denyAll(
-                UsercentricsConsentType.values()[consentType]
+                UsercentricsConsentType.values()[consentType.toInt()]
             ).toWritableArray()
         )
     }
@@ -169,42 +169,42 @@ internal class RNUsercentricsModule(
     @ReactMethod
     override fun saveDecisionsForTCF(
         tcfDecisions: ReadableMap,
-        fromLayer: Int,
+        fromLayer: Double,
         saveDecisions: ReadableArray,
-        consentType: Int,
+        consentType: Double,
         promise: Promise
     ) {
         promise.resolve(
             usercentricsProxy.instance.saveDecisionsForTCF(
                 tcfDecisions.deserializeTCFUserDecisions(),
-                TCFDecisionUILayer.values()[fromLayer],
+                TCFDecisionUILayer.values()[fromLayer.toInt()],
                 saveDecisions.deserializeUserDecision(),
-                UsercentricsConsentType.values()[consentType]
+                UsercentricsConsentType.values()[consentType.toInt()]
             ).toWritableArray()
         )
     }
 
     @ReactMethod
-    override fun saveDecisions(decisions: ReadableArray, consentType: Int, promise: Promise) {
+    override fun saveDecisions(decisions: ReadableArray, consentType: Double, promise: Promise) {
         promise.resolve(
             usercentricsProxy.instance.saveDecisions(
-                decisions.deserializeUserDecision(), UsercentricsConsentType.values()[consentType]
+                decisions.deserializeUserDecision(), UsercentricsConsentType.values()[consentType.toInt()]
             ).toWritableArray()
         )
     }
 
     @ReactMethod
-    override fun saveOptOutForCCPA(isOptedOut: Boolean, consentType: Int, promise: Promise) {
+    override fun saveOptOutForCCPA(isOptedOut: Boolean, consentType: Double, promise: Promise) {
         promise.resolve(
             usercentricsProxy.instance.saveOptOutForCCPA(
-                isOptedOut, UsercentricsConsentType.values()[consentType]
+                isOptedOut, UsercentricsConsentType.values()[consentType.toInt()]
             ).toWritableArray()
         )
     }
 
     @ReactMethod
-    override fun track(event: Int) {
-        usercentricsProxy.instance.track(UsercentricsAnalyticsEventType.values()[event])
+    override fun track(event: Double) {
+        usercentricsProxy.instance.track(UsercentricsAnalyticsEventType.values()[event.toInt()])
     }
 
     @ReactMethod

--- a/android/src/main/java/com/usercentrics/reactnative/RNUsercentricsModuleSpec.kt
+++ b/android/src/main/java/com/usercentrics/reactnative/RNUsercentricsModuleSpec.kt
@@ -55,7 +55,7 @@ abstract class RNUsercentricsModuleSpec internal constructor(context: ReactAppli
     abstract fun getABTestingVariant(promise: Promise)
 
     @ReactMethod
-    abstract fun setCMPId(id: Int)
+    abstract fun setCMPId(id: Double)
 
     @ReactMethod
     abstract fun setABTestingVariant(variant: String)
@@ -64,34 +64,34 @@ abstract class RNUsercentricsModuleSpec internal constructor(context: ReactAppli
     abstract fun changeLanguage(language: String, promise: Promise)
 
     @ReactMethod
-    abstract fun acceptAll(consentType: Int, promise: Promise)
+    abstract fun acceptAll(consentType: Double, promise: Promise)
 
     @ReactMethod
-    abstract fun acceptAllForTCF(fromLayer: Int, consentType: Int, promise: Promise)
+    abstract fun acceptAllForTCF(fromLayer: Double, consentType: Double, promise: Promise)
 
     @ReactMethod
-    abstract fun denyAll(consentType: Int, promise: Promise)
+    abstract fun denyAll(consentType: Double, promise: Promise)
 
     @ReactMethod
-    abstract fun denyAllForTCF(fromLayer: Int, consentType: Int, unsavedPurposeLIDecisions: ReadableArray, promise: Promise)
+    abstract fun denyAllForTCF(fromLayer: Double, consentType: Double, unsavedPurposeLIDecisions: ReadableArray, promise: Promise)
 
     @ReactMethod
-    abstract fun saveDecisions(decisions: ReadableArray, consentType: Int, promise: Promise)
+    abstract fun saveDecisions(decisions: ReadableArray, consentType: Double, promise: Promise)
 
     @ReactMethod
     abstract fun saveDecisionsForTCF(
         tcfDecisions: ReadableMap,
-        fromLayer: Int,
+        fromLayer: Double,
         saveDecisions: ReadableArray,
-        consentType: Int,
+        consentType: Double,
         promise: Promise
     )
 
     @ReactMethod
-    abstract fun saveOptOutForCCPA(isOptedOut: Boolean, consentType: Int, promise: Promise)
+    abstract fun saveOptOutForCCPA(isOptedOut: Boolean, consentType: Double, promise: Promise)
 
     @ReactMethod
-    abstract fun track(event: Int)
+    abstract fun track(event: Double)
 
     companion object {
         const val NAME = "RNUsercentricsModule"


### PR DESCRIPTION
## **User description**
### **User description**
Codegen generates Double for number, you can check here https://reactnative.dev/docs/appendix

right now your whole TurboModule doesn't work for functions that takes number primitive type.

### **PR Type**
Bug fix

### **Description**
- Replace Int with Double for number parameters in TurboModule methods

- Align with React Native codegen specification for number primitives

- Fix compatibility with Android New Architecture

### Diagram Walkthrough

```mermaid
flowchart LR
  A["RNUsercentricsModuleSpec"] -->|"Update parameter types"| B["Int to Double conversion"]
  B -->|"Affects methods"| C["setCMPId, acceptAll, denyAll, track, etc."]
  C -->|"Ensures compatibility"| D["React Native codegen spec"]
```

<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RNUsercentricsModuleSpec.kt</strong><dd><code>Convert Int parameters to Double in TurboModule spec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/java/com/usercentrics/reactnative/RNUsercentricsModuleSpec.kt

<ul><li>Changed parameter type from <code>Int</code> to <code>Double</code> in <code>setCMPId</code> method<br> <li> Updated <code>acceptAll</code>, <code>acceptAllForTCF</code>, <code>denyAll</code>, <code>denyAllForTCF</code> methods to <br>use <code>Double</code> for numeric parameters<br> <li> Modified <code>saveDecisions</code> and <code>saveDecisionsForTCF</code> methods to accept <br><code>Double</code> instead of <code>Int</code><br> <li> Changed <code>saveOptOutForCCPA</code> and <code>track</code> methods to use <code>Double</code> for numeric <br>parameters</ul>

</details>

  </td>
  <td><a href="https://github.com/Usercentrics/react-native-sdk/pull/180/files#diff-a32575ccaf5a7134fbc50702fc34cc610aabfa13bef8c74e258cb4e78ba8d707">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>


___

## **CodeAnt-AI Description**
Fix numeric parameter handling so TurboModule methods work on Android New Architecture

### What Changed
- Numeric parameters for several public module methods were changed from integer to number so JS numbers are accepted; affected methods include setCMPId, acceptAll, acceptAllForTCF, denyAll, denyAllForTCF, saveDecisions, saveDecisionsForTCF, saveOptOutForCCPA, and track
- Incoming number values are converted to integers before calling the native implementation, preserving existing native behavior while accepting JS numeric types
- Module specification was updated to match the React Native codegen expectation for number primitives so the TurboModule binds correctly on Android New Architecture

### Impact
`✅ Fewer native module failures on Android New Architecture`
`✅ Calls from JS with numeric arguments succeed for consent and tracking methods`
`✅ Consistent behavior for consent-related actions when invoked from React Native`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
