### PR TITLE
feat(MSDK-3172): Consume and expose DPS metadata in AppSDK

### DIFF
--- a/android/src/main/java/com/usercentrics/reactnative/RNUsercentricsModule.kt
+++ b/android/src/main/java/com/usercentrics/reactnative/RNUsercentricsModule.kt
@@ -86,6 +86,16 @@ internal class RNUsercentricsModule(
     }
 
     @ReactMethod
+    override fun getDpsMetadata(templateId: String, promise: Promise) {
+        val metadata = usercentricsProxy.instance.getDpsMetadata(templateId)
+        if (metadata == null) {
+            promise.resolve(null)
+        } else {
+            promise.resolve(metadata.toWritableMap())
+        }
+    }
+
+    @ReactMethod
     override fun getConsents(promise: Promise) {
         promise.resolve(usercentricsProxy.instance.getConsents().toWritableArray())
     }

--- a/android/src/main/java/com/usercentrics/reactnative/RNUsercentricsModuleSpec.kt
+++ b/android/src/main/java/com/usercentrics/reactnative/RNUsercentricsModuleSpec.kt
@@ -61,6 +61,9 @@ abstract class RNUsercentricsModuleSpec internal constructor(context: ReactAppli
     abstract fun getABTestingVariant(promise: Promise)
 
     @ReactMethod
+    abstract fun getDpsMetadata(templateId: String, promise: Promise)
+
+    @ReactMethod
     abstract fun setCMPId(id: Double)
 
     @ReactMethod

--- a/example/ios/exampleTests/Fake/FakeUsercentricsManager.swift
+++ b/example/ios/exampleTests/Fake/FakeUsercentricsManager.swift
@@ -118,6 +118,13 @@ final class FakeUsercentricsManager: UsercentricsManager {
     callback(getTCFDataResponse!)
   }
 
+  var getDpsMetadataResponse: [String: Any]?
+  var getDpsMetadataTemplateId: String?
+  func getDpsMetadata(templateId: String) -> [String: Any]? {
+    getDpsMetadataTemplateId = templateId
+    return getDpsMetadataResponse
+  }
+
   var getAdditionalConsentModeDataResponse: AdditionalConsentModeData?
   func getAdditionalConsentModeData() -> AdditionalConsentModeData {
     return getAdditionalConsentModeDataResponse!

--- a/example/ios/exampleTests/RNUsercentricsModuleTests.swift
+++ b/example/ios/exampleTests/RNUsercentricsModuleTests.swift
@@ -563,6 +563,43 @@ class RNUsercentricsModuleTests: XCTestCase {
     }
   }
 
+  func testGetDpsMetadataWithValidData() {
+    fakeUsercentrics.getDpsMetadataResponse = ["partner": "appsflyer", "source": "campaign_1"]
+    module.getDpsMetadata("template123") { result in
+      guard let result = result as? NSDictionary else {
+        XCTFail()
+        return
+      }
+      XCTAssertEqual("appsflyer", result["partner"] as! String)
+      XCTAssertEqual("campaign_1", result["source"] as! String)
+    } reject: { _, _, _ in
+      XCTFail("Should not go here")
+    }
+    XCTAssertEqual("template123", fakeUsercentrics.getDpsMetadataTemplateId)
+  }
+
+  func testGetDpsMetadataWhenNull() {
+    fakeUsercentrics.getDpsMetadataResponse = nil
+    module.getDpsMetadata("nonExistent") { result in
+      XCTAssertNil(result)
+    } reject: { _, _, _ in
+      XCTFail("Should not go here")
+    }
+  }
+
+  func testGetDpsMetadataWithEmptyMap() {
+    fakeUsercentrics.getDpsMetadataResponse = [:]
+    module.getDpsMetadata("template123") { result in
+      guard let result = result as? NSDictionary else {
+        XCTFail()
+        return
+      }
+      XCTAssertEqual(0, result.count)
+    } reject: { _, _, _ in
+      XCTFail("Should not go here")
+    }
+  }
+
   func testGetAdditionalConsentModeData() {
     let expected = AdditionalConsentModeData(acString: "2~43.46.55~dv.",
                                              adTechProviders: [AdTechProvider(id: 43, name: "AdPredictive", privacyPolicyUrl: "https://adpredictive.com/privacy", consent: true)])

--- a/ios/Manager/UsercentricsManager.swift
+++ b/ios/Manager/UsercentricsManager.swift
@@ -24,6 +24,7 @@ public protocol UsercentricsManager {
     func setGPPConsent(sectionName: String, fieldName: String, value: Any)
     func getTCFData(callback: @escaping (TCFData) -> Void)
     func getABTestingVariant() -> String?
+    func getDpsMetadata(templateId: String) -> [String: Any]?
     func getAdditionalConsentModeData() -> AdditionalConsentModeData
     func onGppSectionChange(callback: @escaping (GppSectionChangePayload) -> Void) -> UsercentricsDisposableEvent<GppSectionChangePayload>
 
@@ -114,6 +115,10 @@ final class UsercentricsManagerImplementation: UsercentricsManager {
 
     func getTCFData(callback: @escaping (TCFData) -> Void) {
         UsercentricsCore.shared.getTCFData(callback: callback)
+    }
+
+    func getDpsMetadata(templateId: String) -> [String: Any]? {
+        return UsercentricsCore.shared.getDpsMetadata(templateId: templateId)
     }
 
     func getAdditionalConsentModeData() -> AdditionalConsentModeData {

--- a/ios/RNUsercentricsModule.swift
+++ b/ios/RNUsercentricsModule.swift
@@ -159,6 +159,11 @@ class RNUsercentricsModule: RCTEventEmitter {
         resolve(usercentricsManager.getABTestingVariant())
     }
 
+    @objc func getDpsMetadata(_ templateId: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
+        let metadata = usercentricsManager.getDpsMetadata(templateId: templateId)
+        resolve(metadata as NSDictionary?)
+    }
+
     @objc func getAdditionalConsentModeData(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) -> Void {
         resolve(usercentricsManager.getAdditionalConsentModeData().toDictionary())
     }

--- a/ios/RNUsercentricsModuleSpec.h
+++ b/ios/RNUsercentricsModuleSpec.h
@@ -36,6 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getCMPData:(RCTPromiseResolveBlock)resolve
             reject:(RCTPromiseRejectBlock)reject;
 
+- (void)getDpsMetadata:(NSString *)templateId
+               resolve:(RCTPromiseResolveBlock)resolve
+                reject:(RCTPromiseRejectBlock)reject;
+
 - (void)getAdditionalConsentModeData:(RCTPromiseResolveBlock)resolve
                               reject:(RCTPromiseRejectBlock)reject;
 

--- a/sample/ios/sampleTests/Fake/FakeUsercentricsManager.swift
+++ b/sample/ios/sampleTests/Fake/FakeUsercentricsManager.swift
@@ -119,6 +119,13 @@ final class FakeUsercentricsManager: UsercentricsManager {
     callback(getTCFDataResponse!)
   }
 
+  var getDpsMetadataResponse: [String: Any]?
+  var getDpsMetadataTemplateId: String?
+  func getDpsMetadata(templateId: String) -> [String: Any]? {
+    getDpsMetadataTemplateId = templateId
+    return getDpsMetadataResponse
+  }
+
   var getAdditionalConsentModeDataResponse: AdditionalConsentModeData?
   func getAdditionalConsentModeData() -> AdditionalConsentModeData {
     return getAdditionalConsentModeDataResponse!

--- a/sample/ios/sampleTests/RNUsercentricsModuleTests.swift
+++ b/sample/ios/sampleTests/RNUsercentricsModuleTests.swift
@@ -564,6 +564,43 @@ class RNUsercentricsModuleTests: XCTestCase {
     }
   }
 
+  func testGetDpsMetadataWithValidData() {
+    fakeUsercentrics.getDpsMetadataResponse = ["partner": "appsflyer", "source": "campaign_1"]
+    module.getDpsMetadata("template123") { result in
+      guard let result = result as? NSDictionary else {
+        XCTFail()
+        return
+      }
+      XCTAssertEqual("appsflyer", result["partner"] as! String)
+      XCTAssertEqual("campaign_1", result["source"] as! String)
+    } reject: { _, _, _ in
+      XCTFail("Should not go here")
+    }
+    XCTAssertEqual("template123", fakeUsercentrics.getDpsMetadataTemplateId)
+  }
+
+  func testGetDpsMetadataWhenNull() {
+    fakeUsercentrics.getDpsMetadataResponse = nil
+    module.getDpsMetadata("nonExistent") { result in
+      XCTAssertNil(result)
+    } reject: { _, _, _ in
+      XCTFail("Should not go here")
+    }
+  }
+
+  func testGetDpsMetadataWithEmptyMap() {
+    fakeUsercentrics.getDpsMetadataResponse = [:]
+    module.getDpsMetadata("template123") { result in
+      guard let result = result as? NSDictionary else {
+        XCTFail()
+        return
+      }
+      XCTAssertEqual(0, result.count)
+    } reject: { _, _, _ in
+      XCTFail("Should not go here")
+    }
+  }
+
   func testGetAdditionalConsentModeData() {
     let expected = AdditionalConsentModeData(acString: "2~43.46.55~dv.",
                                              adTechProviders: [AdTechProvider(id: 43, name: "AdPredictive", privacyPolicyUrl: "https://adpredictive.com/privacy", consent: true)])

--- a/src/NativeUsercentrics.ts
+++ b/src/NativeUsercentrics.ts
@@ -40,6 +40,7 @@ export interface Spec extends TurboModule {
   getGPPData(): Promise<GppData>;
   getGPPString(): Promise<string | null>;
   getABTestingVariant(): Promise<string>;
+  getDpsMetadata(templateId: string): Promise<Record<string, unknown> | null>;
 
   // Configuration Setters
   setCMPId(id: number): void;

--- a/src/Usercentrics.tsx
+++ b/src/Usercentrics.tsx
@@ -100,6 +100,11 @@ export const Usercentrics = {
         return RNUsercentricsModule.getAdditionalConsentModeData();
     },
 
+    getDpsMetadata: async (templateId: string): Promise<Record<string, unknown> | null> => {
+        await RNUsercentricsModule.isReady();
+        return RNUsercentricsModule.getDpsMetadata(templateId);
+    },
+
     changeLanguage: async (language: string): Promise<void> => {
         await RNUsercentricsModule.isReady();
         return RNUsercentricsModule.changeLanguage(language);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -61,6 +61,7 @@ jest.mock("react-native", () => {
         setGPPConsent: jest.fn(),
         track: jest.fn(),
         reset: jest.fn(),
+        getDpsMetadata: jest.fn(),
         clearUserSession: jest.fn(),
         addListener: jest.fn(),
         removeListeners: jest.fn()
@@ -453,6 +454,37 @@ describe('Test Usercentrics Module', () => {
 
         const data = await Usercentrics.getAdditionalConsentModeData();
         expect(data).toStrictEqual(response)
+    })
+
+    test('testGetDpsMetadataWithValidData', async () => {
+        const metadata = { partner: "appsflyer", source: "campaign_1" };
+        RNUsercentricsModule.getDpsMetadata.mockImplementationOnce(
+            (): Promise<any> => Promise.resolve(metadata)
+        )
+
+        const data = await Usercentrics.getDpsMetadata("templateId123");
+        expect(data).toStrictEqual(metadata);
+
+        const call = RNUsercentricsModule.getDpsMetadata.mock.calls[0][0];
+        expect(call).toBe("templateId123");
+    })
+
+    test('testGetDpsMetadataWhenNull', async () => {
+        RNUsercentricsModule.getDpsMetadata.mockImplementationOnce(
+            (): Promise<any> => Promise.resolve(null)
+        )
+
+        const data = await Usercentrics.getDpsMetadata("nonExistentId");
+        expect(data).toBe(null);
+    })
+
+    test('testGetDpsMetadataWithEmptyObject', async () => {
+        RNUsercentricsModule.getDpsMetadata.mockImplementationOnce(
+            (): Promise<any> => Promise.resolve({})
+        )
+
+        const data = await Usercentrics.getDpsMetadata("templateId123");
+        expect(data).toStrictEqual({});
     })
 
     test('testClearUserSession', async () => {

--- a/src/fabric/NativeUsercentricsModule.ts
+++ b/src/fabric/NativeUsercentricsModule.ts
@@ -25,6 +25,7 @@ export interface Spec extends TurboModule {
   getGPPData(): Promise<Object>;
   getGPPString(): Promise<string | null>;
   getABTestingVariant(): Promise<string>;
+  getDpsMetadata(templateId: string): Promise<Object | null>;
 
   // Configuration Setters
   setCMPId(id: number): void;


### PR DESCRIPTION
## **User description**
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `getDpsMetadata(templateId)` method to retrieve metadata for a specified template ID. Returns metadata object or null if unavailable. Now available on iOS and Android platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Expose DPS metadata by template ID in the app SDK**

### What Changed
- Apps can now request DPS metadata for a specific template ID from JavaScript.
- The new call returns the metadata object when found, or `null` when no data exists.
- Android and iOS now both support this response path, including empty metadata objects.
- Added tests covering valid metadata, missing metadata, and empty results.

### Impact
`✅ Retrieve DPS metadata by template ID`
`✅ Clear null responses for missing templates`
`✅ Safer metadata handling in apps`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
