### PR TITLE
fix(ios): remove stale ObjC bridge declarations for showCMP and getTCFString

### DIFF
--- a/ios/RNUsercentricsModule.mm
+++ b/ios/RNUsercentricsModule.mm
@@ -10,10 +10,6 @@
 @interface RCT_EXTERN_MODULE(RNUsercentricsModule, NSObject)
 RCT_EXTERN_METHOD(configure:(NSDictionary *)dict)
 
-RCT_EXTERN_METHOD(showCMP:(NSDictionary *)dict
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(showFirstLayer:(NSDictionary *)dict
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
@@ -27,9 +23,6 @@ RCT_EXTERN_METHOD(restoreUserSession:(NSString *)controllerId
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(isReady:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(getTCFString:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(getControllerId:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
## **User description**
## Problem

The `RNUsercentricsModule.mm` ObjC bridge file declares `RCT_EXTERN_METHOD` entries for `showCMP` and `getTCFString`, but `RNUsercentricsModule.swift` does not implement these methods.

This produces two warnings on every app launch:

```
The objective-c `showCMP:(NSDictionary *)dict resolve:(RCTPromiseResolveBlock)resolve
reject:(RCTPromiseRejectBlock)reject` method signature for the JS method `showCMP` can not
be found in the ObjectiveC definition of the RNUsercentricsModule module.

The objective-c `getTCFString:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject`
method signature for the JS method `getTCFString` can not be found in the ObjectiveC definition
of the RNUsercentricsModule module.
```

## Root Cause

- **`showCMP`** — appears to have been replaced by `showFirstLayer`/`showSecondLayer` but the old bridge declaration was not removed
- **`getTCFString`** — removed from the Swift implementation but the bridge declaration remains

Neither method is referenced by the JS-side API (`NativeUsercentrics.ts` / `Usercentrics.js`).

## Fix

Remove the two stale `RCT_EXTERN_METHOD` declarations from `ios/RNUsercentricsModule.mm`.

## Affected Versions

Present in at least 2.24.4 through 2.25.1.


___

## **CodeAnt-AI Description**
**Remove stale iOS bridge declarations that caused launch warnings**

### What Changed
- Removed unsupported iOS bridge entries for `showCMP` and `getTCFString`
- App launch no longer reports missing native method warnings for these removed calls

### Impact
`✅ Cleaner app startup logs`
`✅ Fewer false native method warnings`
`✅ Less confusion when diagnosing real iOS issues`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
