### PR TITLE
fix(MSDK-3355): Remove stale showCMP and getTCFString bridge declarations

### DIFF
--- a/ios/RNUsercentricsModule.mm
+++ b/ios/RNUsercentricsModule.mm
@@ -10,10 +10,6 @@
 @interface RCT_EXTERN_MODULE(RNUsercentricsModule, NSObject)
 RCT_EXTERN_METHOD(configure:(NSDictionary *)dict)
 
-RCT_EXTERN_METHOD(showCMP:(NSDictionary *)dict
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
 RCT_EXTERN_METHOD(showFirstLayer:(NSDictionary *)dict
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
@@ -27,9 +23,6 @@ RCT_EXTERN_METHOD(restoreUserSession:(NSString *)controllerId
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(isReady:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(getTCFString:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(getControllerId:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
## **User description**
**Summary**
  - Removed RCT_EXTERN_METHOD declarations for showCMP and getTCFString from RNUsercentricsModule.mm — these had no matching @objc func implementations in RNUsercentricsModule.swift
  - With New Architecture (TurboModules), React Native validates all .mm selectors against the Swift class at startup, producing two WARN messages on every iOS cold start

**Test plan**
  - Build and run the sample app on iOS with New Architecture enabled
  - Verify no showCMP / getTCFString warnings appear in console during startup
  - Verify showFirstLayer, showSecondLayer, getTCFData and other methods still work correctly


___

## **CodeAnt-AI Description**
**Remove unsupported iOS bridge methods that caused startup warnings**

### What Changed
- Removed two bridge declarations that had no matching app behavior behind them
- iOS apps using the new React Native architecture no longer show startup warnings for these missing methods
- Existing consent and layer-related actions remain available

### Impact
`✅ Fewer iOS startup warnings`
`✅ Cleaner new-architecture app launch`
`✅ Less noise when checking app logs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed two methods from the module's public interface, making them no longer available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->