### PR TITLE
feat(MSDK-4088): Support PL-5714 new COP restriction fields across TS, Android and iOS

### DIFF
--- a/android/src/main/java/com/usercentrics/reactnative/extensions/UsercentricsCMPDataExtensions.kt
+++ b/android/src/main/java/com/usercentrics/reactnative/extensions/UsercentricsCMPDataExtensions.kt
@@ -12,6 +12,7 @@ import com.usercentrics.sdk.v2.settings.data.CustomizationFont
 import com.usercentrics.sdk.v2.settings.data.FirstLayer
 import com.usercentrics.sdk.v2.settings.data.PublishedApp
 import com.usercentrics.sdk.v2.settings.data.SecondLayer
+import com.usercentrics.sdk.v2.settings.data.ConsentOrPayRestriction
 import com.usercentrics.sdk.v2.settings.data.ConsentOrPaySettings
 import com.usercentrics.sdk.v2.settings.data.TCF2ChangedPurposes
 import com.usercentrics.sdk.v2.settings.data.TCF2Settings
@@ -249,6 +250,7 @@ private fun TCF2Settings.serialize(): WritableMap {
         "selectedATPIds" to selectedATPIds,
         "consentOrPay" to consentOrPay?.serialize(),
         "mandatoryLabel" to mandatoryLabel,
+        "specialFeaturesConsentOrPay" to specialFeaturesConsentOrPay?.map { it.serialize() },
     ).toWritableMap()
 }
 
@@ -447,9 +449,15 @@ private fun TCF2ChangedPurposes?.serialize(): Any? {
     }
     return mapOf(
         "purposes" to purposes,
-        "legIntPurposes" to legIntPurposes
+        "legIntPurposes" to legIntPurposes,
+        "consentOrPay" to consentOrPay?.map { it.serialize() },
     )
 }
+
+private fun ConsentOrPayRestriction.serialize(): Map<String, Any?> = mapOf(
+    "id" to id,
+    "value" to value,
+)
 
 internal fun AdditionalConsentModeData.serialize(): WritableMap {
     return Arguments.createMap().apply {

--- a/ios/Extensions/UsercentricsCMPData+Dict.swift
+++ b/ios/Extensions/UsercentricsCMPData+Dict.swift
@@ -238,6 +238,7 @@ extension TCF2Settings {
             "resurfacePeriod": self.resurfacePeriod,
             "consentOrPay": self.consentOrPay?.toDictionary() as Any,
             "mandatoryLabel": self.mandatoryLabel,
+            "specialFeaturesConsentOrPay": self.specialFeaturesConsentOrPay?.map { $0.toDictionary() } as Any,
         ]
     }
 }
@@ -497,7 +498,17 @@ extension TCF2ChangedPurposes {
     func toDictionary() -> Any {
         return [
             "purposes": purposes,
-            "legIntPurposes": legIntPurposes
+            "legIntPurposes": legIntPurposes,
+            "consentOrPay": consentOrPay?.map { $0.toDictionary() } as Any,
+        ]
+    }
+}
+
+extension ConsentOrPayRestriction {
+    func toDictionary() -> [String: Any] {
+        return [
+            "id": self.id,
+            "value": self.value,
         ]
     }
 }

--- a/src/models/TCF2Settings.tsx
+++ b/src/models/TCF2Settings.tsx
@@ -60,6 +60,7 @@ export class TCF2Settings {
     selectedATPIds: number[]
     consentOrPay?: TCF2ConsentOrPaySettings
     mandatoryLabel: string
+    specialFeaturesConsentOrPay?: ConsentOrPayRestriction[]
 
     constructor(
         firstLayerTitle: string,
@@ -123,6 +124,7 @@ export class TCF2Settings {
         dataSharedOutsideEUText?: string,
         consentOrPay?: TCF2ConsentOrPaySettings,
         mandatoryLabel: string = 'Mandatory',
+        specialFeaturesConsentOrPay?: ConsentOrPayRestriction[],
     ) {
         this.firstLayerTitle = firstLayerTitle
         this.secondLayerTitle = secondLayerTitle
@@ -185,6 +187,7 @@ export class TCF2Settings {
         this.selectedATPIds = selectedATPIds
         this.consentOrPay = consentOrPay
         this.mandatoryLabel = mandatoryLabel
+        this.specialFeaturesConsentOrPay = specialFeaturesConsentOrPay
     }
 }
 
@@ -204,13 +207,30 @@ export class TCF2ChangedPurposes {
 
     purposes: [number]
     legIntPurposes: [number]
+    consentOrPay?: ConsentOrPayRestriction[]
 
     constructor(
         purposes: [number],
         legIntPurposes: [number],
+        consentOrPay?: ConsentOrPayRestriction[],
     ) {
         this.purposes = purposes
         this.legIntPurposes = legIntPurposes
+        this.consentOrPay = consentOrPay
+    }
+}
+
+export class ConsentOrPayRestriction {
+    id: number
+    value: string
+
+    constructor(id: number, value: string) {
+        this.id = id
+        this.value = value
+    }
+
+    isFlexible(): boolean {
+        return this.value?.toUpperCase() === 'FLEXIBLE'
     }
 }
 


### PR DESCRIPTION
## Summary

Adds support for the new PL-5714 JSON schema fields across all three bridge layers.

**New class:** `ConsentOrPayRestriction` — `{id: number, value: 'FLEXIBLE'|'MANDATORY'}` with `isFlexible()` helper

**Updated:** `TCF2ChangedPurposes` — new `consentOrPay?: ConsentOrPayRestriction[]` field
**Updated:** `TCF2Settings` — new `specialFeaturesConsentOrPay?: ConsentOrPayRestriction[]` field

Both Android and iOS bridges serialize the new fields. Old `publisherRestrictions` and `specialFeatures` maps are kept for backwards compatibility.

Part of the PUR model fix tracked in [MSDK-4088](https://usercentrics.atlassian.net/browse/MSDK-4088). Native SDK changes are in [mobile-sdk PR #2401](https://bitbucket.org/usercentricscode/mobile-sdk/pull-requests/2401).

## Test plan

- [ ] TypeScript: `ConsentOrPayRestriction` exported correctly, new fields present on `TCF2Settings` and `TCF2ChangedPurposes`
- [ ] Android: `UsercentricsCMPDataExtensions` serializes `specialFeaturesConsentOrPay` and `changedPurposes.consentOrPay`
- [ ] iOS: `UsercentricsCMPData+Dict` serializes both new fields
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added comprehensive Consent-or-Pay restrictions support for enhanced management of consent preferences with greater flexibility
- Extended consent management capabilities to include special features with full Consent-or-Pay configuration options
- Implemented automatic detection mechanism for flexible Consent-or-Pay restrictions to streamline workflows
- Enhanced overall data serialization and consistency across Android, iOS, and web platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->