### PR TITLE
Release: 2.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 [Release Notes](https://docs.usercentrics.com/cmp_in_app_sdk/latest/about/history/)
+### 2.28.2 – Jul 22, 2026
+## Fixes
+* **[iOS]** Rebuilt `UsercentricsUI.xcframework` with the Xcode 26 / Swift 6.3.3 toolchain, fixing build failures on Xcode 26.6 for apps consuming 2.27.1/2.28.0 (including via the React Native bridge)
+* **[PUR]** Fixed Consent-or-Pay mandatory purposes silently overriding the user's real TCF consent state on SDK initialization, causing a desync between the SDK's consent getters and the persisted TC string
+* **[TCF]** Removed Special Purposes from the first layer of the TCF banner — not a first-layer requirement
+* **[TCF]** Fixed purposes and special features being disclosed in the second layer (and included in the TC string) even when no vendor declared them, when Stacks are enabled
+
 ### 2.28.1 – Jul 15, 2026
 ## Fixes
 * **[iOS — Mediation]** Fixed AppLovin CCPA `setDoNotSell` always passing `YES` regardless of the actual consent value

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,4 +1,4 @@
-val usercentricsVersion = "2.28.1"
+val usercentricsVersion = "2.28.2"
 val reactNativeVersion = "+"
 
 fun BooleanProperty(name: String): Boolean {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@usercentrics/react-native-sdk",
-  "version": "2.28.1",
+  "version": "2.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@usercentrics/react-native-sdk",
-      "version": "2.28.1",
+      "version": "2.28.2",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
         "@babel/core": "^7.25.10",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@usercentrics/react-native-sdk",
-  "version": "2.28.1",
+  "version": "2.28.2",
   "description": "Usercentrics SDK",
   "homepage": "https://usercentrics.com",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "author": "Usercentrics <developer@usercentrics.com>",
   "iosPackageName": "react-native-usercentrics",
-  "iosPackageVersion": "2.28.1",
+  "iosPackageVersion": "2.28.2",
   "license": "SEE LICENSE IN LICENSE",
   "files": [
     "android",

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -1924,7 +1924,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-usercentrics (2.28.1):
+  - react-native-usercentrics (2.28.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -1951,7 +1951,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - UsercentricsUI (= 2.28.1)
+    - UsercentricsUI (= 2.28.2)
     - Yoga
   - react-native-webview (13.16.1):
     - boost
@@ -2546,9 +2546,9 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
-  - Usercentrics (2.28.1)
-  - UsercentricsUI (2.28.1):
-    - Usercentrics (= 2.28.1)
+  - Usercentrics (2.28.2)
+  - UsercentricsUI (2.28.2):
+    - Usercentrics (= 2.28.2)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2850,7 +2850,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: f84e59c14ff145295fbd029c5be16805aabe98d2
   React-microtasksnativemodule: 584eb07c9b1f1e684fe63b7fae61ed865f8f228f
   react-native-safe-area-context: 7e0ba374906d8f5009aaf96cd19d4866d8de342b
-  react-native-usercentrics: a1f2696c925473e81285d655d6f5f7c8294ee035
+  react-native-usercentrics: 581b7026e7cc7d6a14a18ee1ee3f5f1add8f81b2
   react-native-webview: 21fdd62caca650645e429b4a84941626612616ef
   React-NativeModulesApple: dcfbe72c5a47baec0699a2935c080b7de0c8657b
   React-oscompat: 93b5535ea7f7dff46aaee4f78309a70979bdde9d
@@ -2884,8 +2884,8 @@ SPEC CHECKSUMS:
   ReactCommon: a42100667ef42807c485a579847a5ec2c99e0a82
   RNScreens: 656e050942ae9445f5cc45d05d57f13ce7a4c8e4
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Usercentrics: ebc354ea9d6a8c266bd6af52d2a947ae8f8ad23a
-  UsercentricsUI: ee98a324992a0aa466703d9b7965934bdc868c61
+  Usercentrics: d582dd2a4d474f7521fb1c69b0ad2e36306c8f60
+  UsercentricsUI: 82c26e8bd40ad89fd4106b53f45ba773eb742429
   Yoga: 9b30b783a17681321b52ac507a37219d7d795ace
 
 PODFILE CHECKSUM: 8d257452e9e69d13384a99ee3cd38b42636521da


### PR DESCRIPTION
## **User description**
## Summary
- Bump SDK version to 2.28.2 across `package.json`, `package-lock.json`, and `android/build.gradle.kts`
- Update `sample/ios/Podfile.lock` to pin `UsercentricsUI`/`Usercentrics` 2.28.2
- CHANGELOG entry for 2.28.2 fixes (iOS Xcode 26 build fix, PUR consent desync fix, TCF banner/second-layer fixes)

## Test plan
- [x] `yarn compile` (TS build) passes
- [x] `yarn test` — 34/34 passing
- [x] `yarn lint` — pre-existing warnings/errors only, unrelated to this diff (verified via stash comparison)
- [x] `pod install` in `sample/ios` resolves `UsercentricsUI (2.28.2)` cleanly
- [x] Android `./gradlew :app:dependencies` resolves `com.usercentrics.sdk:usercentrics-ui:2.28.2` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Release 2.28.2 with iOS and consent-state fixes**

### What Changed
- Bumped the SDK version to 2.28.2 across the package files and Android build settings
- Updated the changelog with the 2.28.2 release notes
- This release fixes iOS build failures on Xcode 26.6, keeps Consent-or-Pay consent state in sync with the saved TC string, and corrects TCF banner and second-layer consent display

### Impact
`✅ Successful installs on Xcode 26.6`
`✅ Fewer consent-state mismatches after app start`
`✅ Clearer TCF consent screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Consent-or-Pay initialization so mandatory purposes no longer override the actual TCF consent state.
  * Removed Special Purposes from the first TCF consent banner layer.
  * Corrected second-layer disclosures and TC-string inclusion for purposes and special features when vendor declarations are unavailable.
  * Updated the iOS framework build for improved compatibility with the latest Xcode and Swift toolchain.
* **Chores**
  * Updated the SDK release to version 2.28.2 across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->